### PR TITLE
Comment out gmetad's Graphite config defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,18 +52,20 @@ ganglia_config_gmetad:
     - 'CPU'    
   case_sensitive_hostnames: 0
 
-# Graphite support parameters.
+# Graphite support parameters.  
+# Uncomment and configure these if you're using Graphite.
   
-  carbon_server: 'my.graphite.box'
-  carbon_port: 2003
-  carbon_protocol: 'tcp'
-  graphite_prefix: 'datacenter1.gmetad'
-  graphite_path: '"datacenter1.gmetad.%s.%h.%m'
-  carbon_timeout: 500
+#  carbon_server: 'my.graphite.box'
+#  carbon_port: 2003
+#  carbon_protocol: 'tcp'
+#  graphite_prefix: 'datacenter1.gmetad'
+#  graphite_path: '"datacenter1.gmetad.%s.%h.%m'
+#  carbon_timeout: 500
   
 # Memcached support parameters.
+# Uncomment and configure these if you're using Memcached.
 
-  memcached_parameters: "--SERVER=127.0.0.1"
+#  memcached_parameters: "--SERVER=127.0.0.1"
 
 
 # Ganglia Monitors


### PR DESCRIPTION
The configuration defaults for Graphite were causing my gmetad to fail silently, as shown by this manual run of gmetad:

```
# /usr/sbin/gmetad --debug=1
Sources are ...
Source: [ds1, step 15] has 1 sources
        xxx.xxx.xxx.xxx
Data thread 140487519790848 is monitoring [ds1] data source
        xxx.xxx.xxx.xxx
Unknown host my.graphite.box.
```

Without the `--debug=1` it just dies silently.
